### PR TITLE
CI pour le build vite automatisé 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,24 @@
+name: Build on staging
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: |
+          composer install
+          npm install
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git config push.default current
+          git checkout -b build/main
+          npm run build
+          git add .
+          git commit -m "build"
+          git push origin build/main --force

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 /.phpunit.cache
 /node_modules
-/public/build
 /public/hot
 /public/storage
 /storage/*.key


### PR DESCRIPTION
## Ça fait quoi?
Dès qu'un push est fait sur main, le bot pull main, build vite, et force push sur la branche build/main
## Penser à autoriser les bot github à push :
- Aller dans paramètres
- Actions
- Cocher "Read and write permissions"
- Cliquer sur sauvegarder
![image](https://user-images.githubusercontent.com/28672596/224351236-8d715725-1ceb-4852-a71d-664fcf014824.png)
